### PR TITLE
Remove disallow rule for text2speech on macOS arm64

### DIFF
--- a/template/patches/net.minecraft.json
+++ b/template/patches/net.minecraft.json
@@ -98,12 +98,6 @@
                 {
                     "action": "disallow",
                     "os": {
-                        "name": "osx-arm64"
-                    }
-                },
-                {
-                    "action": "disallow",
-                    "os": {
                         "name": "linux-arm64"
                     }
                 },


### PR DESCRIPTION
text2speech lib on macOS does not directly include native binaries, so adding the right java-objc is enough