### PR TITLE
Fix: arm64 not launch-able with Prism launcher

### DIFF
--- a/main.py
+++ b/main.py
@@ -125,6 +125,11 @@ with (open(installer_patches_path, 'r') as __in,
         if 'org.lwjgl3:' in kd['name']:
             if not lwjgl_version:
                 lwjgl_version = str(kd['name']).split(':')[2]
+            # Temp fix for prism launcher (allow ARM64 arch)
+            if '-arm64' in kd['name']:
+                temp = {'action': 'allow'}
+                temp['os']['name'] = kd['rules'][0]['os']['name'] + "-arm64"
+                kd['rules'].append(temp)
             lwjgl_patches_json['libraries'].append(kd)
         else:
             if 'com.cleanroommc:cleanroom' in kd['name']:


### PR DESCRIPTION
Prism has a different meta OS name for ARM64, this commit append a second OS rule like prism metadata file